### PR TITLE
Bug fix: Handle not declared role inside a view

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 codecov
 django>=1.11,<2.0
-pytest
+pytest>=3.6
 pytest-cov
 pytest-django
 twine

--- a/rest_framework_role_filters/role_filters.py
+++ b/rest_framework_role_filters/role_filters.py
@@ -32,7 +32,10 @@ class RoleFilterGroup:
         return role_filter.trigger_filter(filter_name, *args, **kwargs)
 
     def get_allowed_actions(self, role_id, request, view):
-        return self.trigger_filter('get_allowed_actions', role_id, request, view)
+        allowed_actions = self.trigger_filter('get_allowed_actions', role_id, request, view)
+        if allowed_actions is None:
+            return []
+        return allowed_actions
 
     def get_queryset(self, role_id, request, view, queryset):
         return self.trigger_filter('get_queryset', role_id, request, view, queryset)

--- a/testproject/tests/conftest.py
+++ b/testproject/tests/conftest.py
@@ -20,6 +20,13 @@ def user_with_user_role(django_user_model):
 
 
 @pytest.fixture
+def user_with_no_declared_role_in_view(django_user_model):
+    user = django_user_model.objects.create_user('user', 'user@email.com', '123456')
+    UserRole.objects.create(user=user, role_id='no_post_access')
+    return user
+
+
+@pytest.fixture
 def client_admin_logged(client):
     client = APIClient()
     client.login(username='admin', password='123456')

--- a/testproject/tests/testapp/test_views.py
+++ b/testproject/tests/testapp/test_views.py
@@ -16,6 +16,13 @@ def test_get_allowed_actions(
     assert response.data == {'detail': 'action=destroy not allowed for role=user'}
 
 
+def test_get_allowed_actions_with_no_declared_role_inside_view(
+        post1, user_with_no_declared_role_in_view, client_user_logged):
+    response = client_user_logged.delete(reverse('testapp:posts-detail', args=[post1.id]))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.data == {'detail': 'action=destroy not allowed for role=no_post_access'}
+
+
 def test_get_queryset(
         post1, post2, user_with_admin_role, user_with_user_role,
         client_admin_logged, client_user_logged):


### PR DESCRIPTION
- Add fixture : user with a none declared role inside post view

- Add test: should raise a 403 when role is not assigned to a view

- Change `get_allowed_actions` to return an empty list when role is not declared inside view