### PR TITLE
Viewset role filter is non existant on docs gen. Sets None for attrib…

### DIFF
--- a/rest_framework_role_filters/viewsets.py
+++ b/rest_framework_role_filters/viewsets.py
@@ -3,6 +3,7 @@ from rest_framework.viewsets import ModelViewSet
 
 class RoleFilterModelViewSet(ModelViewSet):
     role_filter_group = None
+    role_id = None
 
     def get_role_id(self, request):
         pass


### PR DESCRIPTION
Viewset role filter is non existant on docs gen. Sets None for attribute to allow docs to work.