### PR TITLE
RoleFilterMixin and object-level get_allowed_actions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 0.2.4
 ~~~~~
 
-* using mixin approach for RoleFilterModelViewSet: code moved to RoleFilterMixin
+* Using mixin approach for RoleFilterModelViewSet: code moved to RoleFilterMixin.
+* get_allowed_actions now also accepts :code:`obj` argument that is used to verify actions
+  allowed during :code:`check_object_permissions`.
 
 0.2.3
 ~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.2.4
+~~~~~
+
+* using mixin approach for RoleFilterModelViewSet: code moved to RoleFilterMixin
+
 0.2.3
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,11 @@ Create role_filters.py with your roles definitions
     class UserRoleFilter(RoleFilter):
         role_id = 'user'
 
-        def get_allowed_actions(self, request, view):
+        def get_allowed_actions(self, request, view, obj=None):
+            # This example returns same list both for "global permissions" check,
+            # and for "object" permissions, but different list may be returned
+            # if `obj` argument is not None, and this list will be used to check
+            # if action is allowed during call to `ViewSet.check_object_permissions`
             return ['create', 'list', 'retrieve', 'update', 'partial_update']
 
         def get_queryset(self, request, view, queryset):
@@ -104,6 +108,7 @@ If role_id is 'user':
 * Only actions 'create', 'list', 'retrieve', 'update', 'partial_update' are allowed
 * The queryset is filtered by user
 * The :code:`serializer_class=PostSerializerForUser` is used
-* The serializer initializing with :code:`fields` kwargs
+* The serializer initializing with :code:`fields` kwargs  (e.g. for modified serializer as described in
+  `DRF: Dynamically modifying fields <https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields>`_)
 
 Check `testapp example <https://github.com/allisson/django-rest-framework-role-filters/tree/master/testproject/testapp>`_ code implementation.

--- a/README.rst
+++ b/README.rst
@@ -94,16 +94,16 @@ Create viewset and override get_role_id method
 
 If role_id is 'admin':
 
-* All actions is allowed
-* The default queryset is returned - Post.objects.all()
-* The default serializer_class is used - PostSerializer
-* The default viewset get_serializer method is used
+* All actions are allowed
+* The default queryset is returned - :code:`Post.objects.all()`
+* The default :code:`serializer_class` is used - :code:`PostSerializer`
+* The default viewset :code:`get_serializer` method is used
 
 If role_id is 'user':
 
-* Only actions 'create', 'list', 'retrieve', 'update', 'partial_update' is allowed
+* Only actions 'create', 'list', 'retrieve', 'update', 'partial_update' are allowed
 * The queryset is filtered by user
-* The serializer_class PostSerializerForUser is used
-* The serializer initializing with fields kwargs
+* The :code:`serializer_class=PostSerializerForUser` is used
+* The serializer initializing with :code:`fields` kwargs
 
 Check `testapp example <https://github.com/allisson/django-rest-framework-role-filters/tree/master/testproject/testapp>`_ code implementation.

--- a/rest_framework_role_filters/mixins.py
+++ b/rest_framework_role_filters/mixins.py
@@ -1,11 +1,3 @@
-from rest_framework.viewsets import ModelViewSet
-
-__all__ = [
-    'RoleFilterMixin',
-    'RoleFilterModelViewSet'
-]
-
-
 class RoleFilterMixin(object):
     role_filter_group = None
     role_id = None
@@ -48,7 +40,3 @@ class RoleFilterMixin(object):
         if filtered_serializer is None:
             return serializer_class(*args, **kwargs)
         return filtered_serializer
-
-
-class RoleFilterModelViewSet(RoleFilterMixin, ModelViewSet):
-    pass

--- a/rest_framework_role_filters/mixins.py
+++ b/rest_framework_role_filters/mixins.py
@@ -1,3 +1,8 @@
+import warnings
+
+__all__ = ['RoleFilterMixin']
+
+
 class RoleFilterMixin(object):
     role_filter_group = None
     role_id = None
@@ -40,3 +45,13 @@ class RoleFilterMixin(object):
         if filtered_serializer is None:
             return serializer_class(*args, **kwargs)
         return filtered_serializer
+
+    def check_object_permissions(self, request, obj):
+        super(RoleFilterMixin, self).check_object_permissions(request, obj)
+
+        allowed_actions = self.role_filter_group.get_allowed_actions(self.role_id, request, self, obj=obj)
+        if self.action not in allowed_actions:
+            self.permission_denied(
+                request,
+                message='action={} not allowed for role={}'.format(self.action, self.role_id)
+            )

--- a/rest_framework_role_filters/mixins.py
+++ b/rest_framework_role_filters/mixins.py
@@ -1,7 +1,12 @@
 from rest_framework.viewsets import ModelViewSet
 
+__all__ = [
+    'RoleFilterMixin',
+    'RoleFilterModelViewSet'
+]
 
-class RoleFilterModelViewSet(ModelViewSet):
+
+class RoleFilterMixin(object):
     role_filter_group = None
     role_id = None
 
@@ -9,7 +14,7 @@ class RoleFilterModelViewSet(ModelViewSet):
         pass
 
     def initial(self, request, *args, **kwargs):
-        super(RoleFilterModelViewSet, self).initial(request, *args, **kwargs)
+        super(RoleFilterMixin, self).initial(request, *args, **kwargs)
         self.role_id = self.get_role_id(request)
         allowed_actions = self.role_filter_group.get_allowed_actions(self.role_id, request, self)
         if self.action not in allowed_actions:
@@ -19,14 +24,14 @@ class RoleFilterModelViewSet(ModelViewSet):
             )
 
     def get_queryset(self):
-        queryset = super(RoleFilterModelViewSet, self).get_queryset()
+        queryset = super(RoleFilterMixin, self).get_queryset()
         filtered_queryset = self.role_filter_group.get_queryset(self.role_id, self.request, self, queryset)
         if filtered_queryset is None:
             return queryset
         return filtered_queryset
 
     def get_serializer_class(self):
-        serializer_class = super(RoleFilterModelViewSet, self).get_serializer_class()
+        serializer_class = super(RoleFilterMixin, self).get_serializer_class()
         filtered_serializer_class = self.role_filter_group.get_serializer_class(
             self.role_id, self.request, self
         )
@@ -43,3 +48,7 @@ class RoleFilterModelViewSet(ModelViewSet):
         if filtered_serializer is None:
             return serializer_class(*args, **kwargs)
         return filtered_serializer
+
+
+class RoleFilterModelViewSet(RoleFilterMixin, ModelViewSet):
+    pass

--- a/rest_framework_role_filters/viewsets.py
+++ b/rest_framework_role_filters/viewsets.py
@@ -1,0 +1,10 @@
+from rest_framework.viewsets import ModelViewSet
+from .mixins import RoleFilterMixin
+
+__all__ = [
+    'RoleFilterModelViewSet'
+]
+
+
+class RoleFilterModelViewSet(RoleFilterMixin, ModelViewSet):
+    pass

--- a/testproject/testapp/role_filters.py
+++ b/testproject/testapp/role_filters.py
@@ -10,7 +10,7 @@ class AdminRoleFilter(RoleFilter):
 class UserRoleFilter(RoleFilter):
     role_id = 'user'
 
-    def get_allowed_actions(self, request, view):
+    def get_allowed_actions(self, request, view, obj=None):
         return ['create', 'list', 'retrieve', 'update', 'partial_update']
 
     def get_queryset(self, request, view, queryset):
@@ -31,3 +31,23 @@ class UserRoleFilter(RoleFilter):
             'user',
         )
         return serializer_class(*args, fields=fields, **kwargs)
+
+
+class ObjLevelUserRoleFilter(UserRoleFilter):
+    role_id = 'obj_level_user'
+
+    def get_allowed_actions(self, request, view, obj=None):
+        if obj is None:
+            return ['create', 'list', 'retrieve', 'update', 'partial_update']
+        else:
+            # This is strange but enough for tests. In real app you should probably check
+            # user against some obj fields.
+            return ['retrieve', 'partial_update']
+
+
+
+class DeprecatedUserRoleFilter(UserRoleFilter):
+    role_id = 'deprecated_user'
+
+    def get_allowed_actions(self, request, view):
+        return ['create', 'list', 'retrieve', 'update', 'partial_update']

--- a/testproject/testapp/views.py
+++ b/testproject/testapp/views.py
@@ -2,12 +2,19 @@ from rest_framework_role_filters.role_filters import RoleFilterGroup
 from rest_framework_role_filters.viewsets import RoleFilterModelViewSet
 
 from .models import Post
-from .role_filters import AdminRoleFilter, UserRoleFilter
+from .role_filters import AdminRoleFilter, UserRoleFilter, ObjLevelUserRoleFilter, DeprecatedUserRoleFilter
 from .serializers import PostSerializer
 
 
 class PostViewSet(RoleFilterModelViewSet):
-    role_filter_group = RoleFilterGroup(role_filters=[AdminRoleFilter(), UserRoleFilter()])
+    role_filter_group = RoleFilterGroup(
+        role_filters=[
+            AdminRoleFilter(),
+            UserRoleFilter(),
+            ObjLevelUserRoleFilter(),
+            DeprecatedUserRoleFilter(),
+        ]
+    )
     queryset = Post.objects.all()
     serializer_class = PostSerializer
 

--- a/testproject/tests/conftest.py
+++ b/testproject/tests/conftest.py
@@ -27,6 +27,20 @@ def user_with_no_declared_role_in_view(django_user_model):
 
 
 @pytest.fixture
+def user_with_obj_level_role_in_view(django_user_model):
+    user = django_user_model.objects.create_user('user', 'user@email.com', '123456')
+    UserRole.objects.create(user=user, role_id='obj_level_user')
+    return user
+
+
+@pytest.fixture
+def user_with_deprecated_role_in_view(django_user_model):
+    user = django_user_model.objects.create_user('user', 'user@email.com', '123456')
+    UserRole.objects.create(user=user, role_id='deprecated_user')
+    return user
+
+
+@pytest.fixture
 def client_admin_logged(client):
     client = APIClient()
     client.login(username='admin', password='123456')
@@ -53,6 +67,24 @@ def post1(user_with_admin_role):
 def post2(user_with_user_role):
     return Post.objects.create(
         user=user_with_user_role,
+        title='My Post Title',
+        body='My Post Body'
+    )
+
+
+@pytest.fixture
+def post3(user_with_obj_level_role_in_view):
+    return Post.objects.create(
+        user=user_with_obj_level_role_in_view,
+        title='My Post Title',
+        body='My Post Body'
+    )
+
+
+@pytest.fixture
+def post4(user_with_deprecated_role_in_view):
+    return Post.objects.create(
+        user=user_with_deprecated_role_in_view,
         title='My Post Title',
         body='My Post Body'
     )

--- a/testproject/tests/testapp/test_views.py
+++ b/testproject/tests/testapp/test_views.py
@@ -1,3 +1,6 @@
+import json
+import warnings
+
 import pytest
 from django.urls import reverse
 from rest_framework import status
@@ -21,6 +24,49 @@ def test_get_allowed_actions_with_no_declared_role_inside_view(
     response = client_user_logged.delete(reverse('testapp:posts-detail', args=[post1.id]))
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data == {'detail': 'action=destroy not allowed for role=no_post_access'}
+
+
+def test_get_allowed_actions_with_obj_level_role_inside_view(
+        post3, user_with_obj_level_role_in_view, client_user_logged):
+    url = reverse('testapp:posts-detail', args=[post3.id])
+    json_c_t = 'application/json'
+
+    response = client_user_logged.get(url)
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client_user_logged.put(
+        url,
+        data={'title': 'new', 'body': 'new_body'},
+        content_type=json_c_t,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.data == {'detail': 'action=update not allowed for role=obj_level_user'}
+
+    response = client_user_logged.patch(
+        url,
+        data=json.dumps({'title': 'new title'}),
+        content_type=json_c_t,
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client_user_logged.get(reverse('testapp:posts-list'))
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_deprecated_get_allowed_actions(
+        post4, user_with_deprecated_role_in_view, client_user_logged):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        response = client_user_logged.delete(reverse('testapp:posts-detail', args=[post4.id]))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data == {'detail': 'action=destroy not allowed for role=deprecated_user'}
+
+        assert len(w) >= 1
+        assert issubclass(w[-1].category, PendingDeprecationWarning)
+        msg = str(w[-1].message)
+        assert "deprecated" in msg
+        assert "`obj` argument" in msg
+
 
 
 def test_get_queryset(


### PR DESCRIPTION
Moved logic from `viewsets.RoleFilterModelViewSet` to `mixins.RoleFilterMixin`, and changed viewset to use this mixin. This allows to use RoleFilterMixin for GenericAPIView subclasses.

`get_allowed_actions` now also has optional `obj` argument that is used to check allowed actions during call to `ViewSet.check_object_permissions`