### PR TITLE
Avoid error with get_schema_view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+1.0.1
+~~~~~
+
+* Create property role_filter_group on RoleFilterMixin to avoid error with get_schema_view.
+
 1.0.0
 ~~~~~
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,7 @@ isort
 pytest
 pytest-cov
 pytest-django
+pyyaml
 twine
+uritemplate
 wheel

--- a/rest_framework_role_filters/mixins.py
+++ b/rest_framework_role_filters/mixins.py
@@ -8,13 +8,16 @@ class RoleFilterMixin:
     role_filter_group = None
     role_id = None
 
+    @property
+    def role_filter_group(self):
+        return self.get_role_filter_group()
+
     def get_role_id(self, request):
         pass
 
     def initial(self, request, *args, **kwargs):
         super().initial(request, *args, **kwargs)
         self.role_id = self.get_role_id(request)
-        self.role_filter_group = self.get_role_filter_group()
         allowed_actions = self.role_filter_group.get_allowed_actions(self.role_id, request, self)
         if self.action not in allowed_actions:
             self.permission_denied(

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,5 +1,15 @@
 from django.conf.urls import include, url
+from rest_framework.permissions import AllowAny
+from rest_framework.schemas import get_schema_view
 
 urlpatterns = [
     url(r"^api/", include("testapp.urls")),
+]
+
+urlpatterns += [
+    url(
+        r"^openapi-schema",
+        get_schema_view(title="Tutorial app", description="tutorial app", version="1.0.0",),
+        name="openapi-schema",
+    ),
 ]

--- a/testproject/tests/testapp/test_views.py
+++ b/testproject/tests/testapp/test_views.py
@@ -101,3 +101,10 @@ def test_get_serializer(
     response = client_user_logged.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert "admin_only_field" not in response.data["results"][0]
+
+
+def test_schema_view(user_with_user_role, client_user_logged):
+    url = reverse("openapi-schema")
+
+    response = client_user_logged.get(url)
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Create property role_filter_group on RoleFilterMixin to avoid error with get_schema_view.

Fixes #15.